### PR TITLE
[graphviz] show network address in hexastring format

### DIFF
--- a/lib/extension/networkMap.js
+++ b/lib/extension/networkMap.js
@@ -49,9 +49,10 @@ class NetworkMap {
             const labels = [];
             const friendlyDevice = settings.getDevice(device.ieeeAddr);
             const friendlyName = friendlyDevice ? friendlyDevice.friendly_name : device.ieeeAddr;
-
+            const nwkAddr = "0x" + device.nwkAddr.toString(16);
+            
             // Add friendly name
-            labels.push(`${friendlyName}:${device.nwkAddr}`);
+            labels.push(`${friendlyName}:${nwkAddr}`);
 
             // Add the device type
             const deviceType = utils.correctDeviceType(device);


### PR DESCRIPTION
Wireshark shows network address in hexadecimal format, so it's easier to follow messages in Wireshark if both shows address in same format.